### PR TITLE
Fix ConcurrentModificationException and chat handler

### DIFF
--- a/src/main/java/altoclef/AltoClefController.java
+++ b/src/main/java/altoclef/AltoClefController.java
@@ -380,7 +380,8 @@ public class AltoClefController {
       return this.owner;
    }
    public String getOwnerUsername(){
-      return getOwner().getName().getString();
+      Player owner = getOwner();
+      return owner != null ? owner.getName().getString() : "Unknown";
    }
 
    public void setOwner(Player owner) {

--- a/src/main/java/altoclef/eventbus/EventBus.java
+++ b/src/main/java/altoclef/eventbus/EventBus.java
@@ -17,63 +17,45 @@
 
 package altoclef.eventbus;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
-import net.minecraft.util.Tuple;
 
+/**
+ * Thread-safe event bus for publishing and subscribing to events.
+ * Uses CopyOnWriteArrayList to allow safe iteration during publish
+ * while subscriptions may be added/removed from other threads.
+ */
 public class EventBus {
-   private static final HashMap<Class, List<Subscription>> topics = new HashMap<>();
-   private static final List<Tuple<Class, Subscription>> toAdd = new ArrayList<>();
-   private static boolean lock;
+   private static final ConcurrentHashMap<Class<?>, CopyOnWriteArrayList<Subscription<?>>> topics = new ConcurrentHashMap<>();
 
    public static <T> void publish(T event) {
       Class<?> type = event.getClass();
+      CopyOnWriteArrayList<Subscription<?>> subscribers = topics.get(type);
 
-      for (Tuple<Class, Subscription> toAdd : EventBus.toAdd) {
-         subscribeInternal((Class<T>)toAdd.getA(), (Subscription<T>)toAdd.getB());
-      }
-
-      EventBus.toAdd.clear();
-      if (topics.containsKey(type)) {
-         List<Subscription> subscribers = topics.get(type);
-         List<Subscription> toDelete = new ArrayList<>();
-         lock = true;
-
-         for (Subscription<T> subRaw : subscribers) {
+      if (subscribers != null) {
+         for (Subscription<?> subRaw : subscribers) {
             try {
                if (subRaw.shouldDelete()) {
-                  toDelete.add(subRaw);
+                  // CopyOnWriteArrayList allows safe removal during iteration
+                  subscribers.remove(subRaw);
                } else {
-                  subRaw.accept(event);
+                  @SuppressWarnings("unchecked")
+                  Subscription<T> sub = (Subscription<T>) subRaw;
+                  sub.accept(event);
                }
-            } catch (ClassCastException var7) {
+            } catch (ClassCastException e) {
                System.err.println("TRIED PUBLISHING MISMAPPED EVENT: " + event);
-               var7.printStackTrace();
+               e.printStackTrace();
             }
          }
-
-         lock = false;
       }
-   }
-
-   private static <T> void subscribeInternal(Class<T> type, Subscription<T> sub) {
-      if (!topics.containsKey(type)) {
-         topics.put(type, new ArrayList<>());
-      }
-
-      topics.get(type).add(sub);
    }
 
    public static <T> Subscription<T> subscribe(Class<T> type, Consumer<T> consumeEvent) {
       Subscription<T> sub = new Subscription<>(consumeEvent);
-      if (lock) {
-         toAdd.add(new Tuple(type, sub));
-      } else {
-         subscribeInternal(type, sub);
-      }
-
+      // computeIfAbsent is atomic - ensures thread-safe initialization
+      topics.computeIfAbsent(type, k -> new CopyOnWriteArrayList<>()).add(sub);
       return sub;
    }
 

--- a/src/main/java/altoclef/eventbus/Subscription.java
+++ b/src/main/java/altoclef/eventbus/Subscription.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
 
 public class Subscription<T> {
    private final Consumer<T> callback;
-   private boolean shouldDelete;
+   private volatile boolean shouldDelete;
 
    public Subscription(Consumer<T> callback) {
       this.callback = callback;

--- a/src/main/java/altoclef/player2api/ForgeEventHandler.java
+++ b/src/main/java/altoclef/player2api/ForgeEventHandler.java
@@ -7,7 +7,7 @@ import net.minecraftforge.fml.common.Mod;
 @Mod.EventBusSubscriber(modid="automatone")
 public class ForgeEventHandler {
     @SubscribeEvent
-    public void onChatMessage(ServerChatEvent evt){
+    public static void onChatMessage(ServerChatEvent evt){
         EventQueueManager.onUserChatMessage(new Event.UserMessage(evt.getMessage().getString(), evt.getUsername()));
     }
 }


### PR DESCRIPTION
Fixes world crashing on load in heavy modpacks (100+ mods) caused by thread-safety issues in EventBus.

Changes:
- EventBus: HashMap → ConcurrentHashMap, ArrayList → CopyOnWriteArrayList
- Subscription: made shouldDelete volatile
- ForgeEventHandler: made onChatMessage static

Tested with CABIN, TerraFirmaGreg & Prehistoric World on Forge 1.20.1.